### PR TITLE
change: comment out AVAudioSession setCategory

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -67,7 +67,8 @@ public class SpeechRecognition: CAPPlugin {
 
             let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
             do {
-                try audioSession.setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.defaultToSpeaker)
+                // NOTE: VTX動画の文字起こしと競合するため、コメントアウトして回避
+                // try audioSession.setCategory(AVAudioSession.Category.playAndRecord, options: AVAudioSession.CategoryOptions.defaultToSpeaker)
                 try audioSession.setMode(AVAudioSession.Mode.default)
                 try audioSession.setActive(true, options: AVAudioSession.SetActiveOptions.notifyOthersOnDeactivation)
             } catch {


### PR DESCRIPTION
### WHAT
Plugin.swift内のaudioSession.setCategoryをコメントアウト

### WHY
VTX動画において、文字起こしをする際に、既存のカテゴリー(+ オプション)設定を上書きして動画が止まってしまうので、それを防ぐため。